### PR TITLE
Fixed download link for tar.gz version

### DIFF
--- a/download.html
+++ b/download.html
@@ -8,7 +8,7 @@ toc: false
   <h1>{{ page.title }}</h1>
   <p>Download DITA Open Toolkit {{site.release}} distribution package:</p>
   <a class="btn btn-large btn-success" href="https://github.com/dita-ot/dita-ot/releases/download/{{site.version}}/DITA-OT{{site.version}}_client_bin.zip">Windows</a>
-  <a class="btn btn-large btn-success" href="https://github.com/dita-ot/dita-ot/releases/download/{{site.version}}/DITA-OT{{site.version}}_client_bin.tar.gz/download">Mac OS X and Linux</a>
+  <a class="btn btn-large btn-success" href="https://github.com/dita-ot/dita-ot/releases/download/{{site.version}}/DITA-OT{{site.version}}_client_bin.tar.gz">Mac OS X and Linux</a>
   <p><a  href="https://github.com/dita-ot/dita-ot/releases/tag/{{site.release}}">Other distribution packages</a>.</p>
 </div>
 <!--h2 id="previous_versions">Development versions</h2>


### PR DESCRIPTION
First pull request ever, fixed a trivial error in the download link for Mac/Linux version (=the tar.gz file).
