### PR TITLE
Increase search results to 10

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -66,7 +66,11 @@
       apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
       indexName: 'dita-ot',
       inputSelector: '#search input[type=text]',
-      debug: false // Set debug to true if you want to inspect the dropdown
+      algoliaOptions: {
+             hitsPerPage: 10,
+             // See https://www.algolia.com/doc/api-reference/api-parameters/
+             },
+      debug: false // Set debug to true if you want to inspect the dropdown,
       });
     </script>
   </body>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -62,15 +62,15 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
     <script src="{{ site.baseurl }}/js/main.js" type="text/javascript" ></script>
-    <script type="text/javascript"> docsearch({
-      apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
-      indexName: 'dita-ot',
-      inputSelector: '#search input[type=text]',
-      algoliaOptions: {
-             hitsPerPage: 10,
-             // See https://www.algolia.com/doc/api-reference/api-parameters/
-             },
-      debug: false // Set debug to true if you want to inspect the dropdown,
+    <script type="text/javascript">
+      docsearch({
+        apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
+        indexName: 'dita-ot',
+        inputSelector: '#search input[type=text]',
+        algoliaOptions: {
+          hitsPerPage: 10,
+        },
+        debug: false
       });
     </script>
   </body>

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -27,7 +27,11 @@
       apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
       indexName: 'dita-ot',
       inputSelector: '#search input[type=text]',
-      debug: false // Set debug to true if you want to inspect the dropdown
+      algoliaOptions: {
+             hitsPerPage: 10,
+             // See https://www.algolia.com/doc/api-reference/api-parameters/
+             },
+      debug: false // Set debug to true if you want to inspect the dropdown,
       });
     </script>
   </body>

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -23,15 +23,15 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
     <script src="{{ site.baseurl }}/js/main.js" type="text/javascript" ></script>
-    <script type="text/javascript"> docsearch({
-      apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
-      indexName: 'dita-ot',
-      inputSelector: '#search input[type=text]',
-      algoliaOptions: {
-             hitsPerPage: 10,
-             // See https://www.algolia.com/doc/api-reference/api-parameters/
-             },
-      debug: false // Set debug to true if you want to inspect the dropdown,
+    <script type="text/javascript">
+      docsearch({
+        apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
+        indexName: 'dita-ot',
+        inputSelector: '#search input[type=text]',
+        algoliaOptions: {
+          hitsPerPage: 10,
+        },
+        debug: false
       });
     </script>
   </body>


### PR DESCRIPTION
## Description
The Algolia search results display the first 5 results. This increases the number shown to 10. The default value of 5 is found in `docsearch.min.js`.

## Motivation and Context
Five results is often not enough to get a sense of whether you're finding the page you need. Ten will provide more context, although it's possible that even 10 is too few.

## How Has This Been Tested?
Built `_site` locally running on http://127.0.0.1:4000/ and typed queries into the search box from the splash page as well as several `dev` pages.

- Change  _(non-breaking change which fixes an issue)_

<img src="https://user-images.githubusercontent.com/10221562/68077743-fd69c580-fd96-11e9-8ed1-5c3822e15f0d.png" height="500px"/>

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>


Signed-off-by: Lief Erickson <lief.erickson@scriptorium.com>
