### PR TITLE
Add Slack invite link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,7 +36,7 @@
               <a class="dropdown-item" href="{{ site.baseurl }}/contributing">How To Contribute</a>
               <a class="dropdown-item" href="{{ site.baseurl }}/management">Project Management</a>
               <a class="dropdown-item" href="{{ site.baseurl }}/who_we_are">Who We Are</a>
-              <a class="dropdown-item" href="http://slack.dita-ot.org">Join us on Slack</a>
+              <a class="dropdown-item" href="https://join.slack.com/t/dita-ot/shared_invite/enQtODMxNjQ0MzAyMDg3LWZhZjk4NmM3MmU4YWI4MTM2NTVkMDg3ZmY4MjA1YzM0ZWI3NmY3NTc5ZmY5NzQ2MGU1NjA4YWIwMTJlMWUyNTY">Join us on Slack</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="https://github.com/dita-ot/dita-ot"
                 >DITA-OT Source Code</a


### PR DESCRIPTION
## Description
Use shared Slack invite link instead of custom invite service.

## Motivation and Context
Use built-in Slack invite functionality that removes the need to host the service ourselves.


