### PR TITLE
Update bio, switch http to https

### DIFF
--- a/who_we_are.html
+++ b/who_we_are.html
@@ -22,9 +22,10 @@ title: 'Who We Are'
       <div class="media-body">
         <h4 class="media-heading">Robert D Anderson</h4>
         <p>
-          Robert is the project lead and core developer of DITA-OT, representing
-          <a href="http://www.ibm.com/">IBM</a>. He's also the co-editor of the OASIS DITA
-          specification.
+          Robert is the project lead and a core developer of DITA-OT, representing
+          <a href="https://www.oracle.com/">Oracle</a>. He's also the co-editor of the OASIS DITA
+          specification and occasionally writes about DITA &amp; DITA-OT at 
+          <a href="http://www.metadita.org/toolkit/">metadita.org</a>.
         </p>
       </div>
     </div>
@@ -42,8 +43,8 @@ title: 'Who We Are'
         <p>
           Jarno is the lead developer of DITA-OT, working on the project as an individual
           contributor in his spare time. He occasionally writes development-related posts at
-          <a href="http://www.elovirta.com/">elovirta.com</a> and is available for commercial
-          projects via <a href="http://www.wunderdog.fi/">Wunderdog</a>.
+          <a href="https://www.elovirta.com/">elovirta.com</a> and is available for commercial
+          projects via <a href="https://www.wunderdog.fi/">Wunderdog</a>.
         </p>
         <div>
           <form


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Updates my bio to the new employer, and adds a link to my DITA blog info. 

Noticed that the old link to IBM used `http` rather than `https`, so I switched a couple of other references to `https` while in there.