### PR TITLE
Add RELAX NG schemas for plugin & project files

### DIFF
--- a/rng/plugin.rnc
+++ b/rng/plugin.rnc
@@ -1,0 +1,82 @@
+# This file is part of the DITA Open Toolkit project.
+#
+# Copyright 2014 Jarno Elovirta
+#
+# See the accompanying LICENSE file for applicable license.
+plugin =
+  element plugin {
+    attribute id { xsd:NCName },
+    attribute version { version }?,
+    (feature | transtype | extension-point | require | metadata | template)*
+  }
+feature =
+  element feature {
+    attribute extension { xsd:NCName },
+    (attribute file { text }
+     | (attribute value { text },
+        attribute type { "file" | "text" }?))?,
+    anyElement*
+  }
+transtype =
+  element transtype {
+    attribute name {
+      list { xsd:NCName+ }
+    },
+    attribute desc { text }?,
+    attribute abstract { xsd:boolean }?,
+    attribute extends {
+      list { xsd:NCName+ }
+    }?,
+    param*
+  }
+param =
+  element param {
+    attribute required { xsd:boolean }?,
+    attribute deprecated { xsd:boolean }?,
+    attribute name {
+      list { xsd:NCName+ }
+    }?,
+    attribute desc { text }?,
+    param.val
+  }
+param.val |=
+  attribute type { "enum" },
+  val*
+param.val |=
+  attribute type { "string" },
+  val*
+param.val |= attribute type { "file" | "dir" | "uri" }
+val =
+  element val {
+    attribute desc { text }?,
+    attribute default { xsd:boolean }?,
+    text
+  }
+extension-point =
+  element extension-point {
+    attribute id { xsd:NCName },
+    attribute name { text }
+  }
+require =
+  element require {
+    attribute plugin { xsd:NCName },
+    attribute version { version }?,
+    attribute importance { "required" | "optional" }?
+  }
+version = text
+metadata =
+  element metadata {
+    attribute type { xsd:NCName },
+    attribute value { text }
+  }
+template =
+  element template {
+    attribute file { text }
+  }
+anyElement =
+  element * {
+    (attribute * { text }
+     | text
+     | anyElement)*
+  }
+start = plugin

--- a/rng/project.rnc
+++ b/rng/project.rnc
@@ -1,0 +1,83 @@
+default namespace = "https://www.dita-ot.org/project"
+
+
+project = 
+## Publication project
+element project { (includes | deliverable | publication | context)* }
+
+includes =
+  ## Include project file
+  element include {
+    attribute href { xsd:anyURI }
+  }
+
+deliverable =
+  ## Project deliverable
+  element deliverable {
+    attribute name { text }?,
+    attribute id { xsd:NCName }?,
+    ((context | context-ref), output, (publication | publication-ref))
+  }
+
+context =
+  ## Context
+  element context {
+    attribute name { text }?,
+    attribute id { xsd:NCName }?,
+    input,
+    profile?
+  }
+
+context-ref =
+  ## Publication reference
+  element context {
+    attribute idref { xsd:NCName }
+  }
+
+input =
+  ## Input resource
+  element input {
+    attribute href { xsd:anyURI }
+  }
+
+## Output directory
+output =
+  element output {
+    attribute href { xsd:anyURI }
+  }
+
+profile = 
+## Filter and highligh profile
+element profile { ditaval+ }
+
+ditaval =
+  ## DITAVAL profile resource
+  element ditaval {
+    attribute href { xsd:anyURI }?,
+    text
+  }
+
+publication =
+  ## Publication
+  element publication {
+    attribute name { text }?,
+    attribute id { xsd:NCName }?,
+    attribute transtype { text },
+    param*
+  }
+
+publication-ref =
+  ## Publication reference
+  element publication {
+    attribute idref { xsd:NCName }
+  }
+
+param =
+  ## Publication parameter
+  element param {
+    attribute name { text },
+    (attribute href { xsd:anyURI }
+     | attribute path { xsd:anyURI }
+     | attribute value { text })
+  }
+start = project


### PR DESCRIPTION
This publishes the RELAX NG compact syntax schemas for our plugin & project files to public URLs that can be referenced in `<?xml-model>` processing instructions and XML catalogs to allow editors to validate these files when stored outside of a DITA-OT distribution.

Sources:

- https://github.com/dita-ot/dita-ot/blob/ca2a1fa/src/main/resources/plugin.rnc
- https://github.com/dita-ot/dita-ot/blob/24b1489/src/main/resources/project.rnc

Partial implementation proposal for https://github.com/dita-ot/dita-ot/issues/3641
