### PR TITLE
Migrate Algolia DocSearch to v3

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -142,18 +142,20 @@
           </li>
         </ul>
 
-        <form class="form-inline" id="search" role="search">
-          <div class="form-group">
-            <label for="q">{% octicon search class:"bg-gradient-light mr-2" %}</label>
-            <input
-              type="text"
-              name="q"
-              class="form-control"
-              maxlength="255"
-              placeholder="Search the latest docs…"
-            />
-          </div>
-        </form>
+        <div id="docsearch">
+          <form class="form-inline" id="search" role="search">
+            <div class="form-group">
+              <label for="q">{% octicon search class:"bg-gradient-light mr-2" %}</label>
+              <input
+                type="text"
+                name="q"
+                class="form-control"
+                maxlength="255"
+                placeholder="Search the latest docs…"
+              />
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </nav>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -82,7 +82,9 @@
     <script src="https://cdn.usefathom.com/script.js" site="MEDTXGXM" defer></script>
     <script type="text/javascript">
       docsearch({
-        apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
+        container: '#docsearch',
+        appId: '3RVXFPL77E',
+        apiKey: '10c10e348f7e5a284187d61528d54b5f',
         indexName: 'dita-ot',
         inputSelector: '#search input[type=text]',
         algoliaOptions: {


### PR DESCRIPTION
## Description

This PR updates our embedded Algolia [DocSearch](https://docsearch.algolia.com) implementation to [DocSearch v3](https://docsearch.algolia.com/docs/docsearch-v3/).

> DocSearch v3 is built on top of the latest version of Algolia Autocomplete, which provides better accessibility, increased responsiveness, themability, a better built-in design, and customizability under low-network conditions.

## Motivation and Context

https://docsearch.algolia.com/docs/migrating-from-legacy

## How Has This Been Tested?

(Can't test locally, submitting PR to test with Netlify preview.)

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

