### PR TITLE
Add 4.0 and 4.1 to plugin registry version selector

### DIFF
--- a/_js/plugins.js
+++ b/_js/plugins.js
@@ -10,6 +10,8 @@ import t from './translations'
 
 const REPOSITORY_URL = 'https://plugins.dita-ot.org/_all.json'
 const VERSIONS = [
+  '4.1',
+  '4.0',
   '3.7',
   '3.6',
   '3.5',
@@ -326,7 +328,7 @@ function details(versions, version) {
   const installCmds = [
     {
       title: t('INSTALL_3_5'),
-      range: ['3.5', '3.6', '3.7'],
+      range: ['3.5', '3.6', '3.7', '4.0', '4.1'],
       cmd: `dita install ${first.name}`,
     },
     {


### PR DESCRIPTION
## Description
Add 4.0 and 4.1 to plugin registry version selector

## Motivation and Context
Version 4.0 and 4.1 have not been added.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- New feature _(non-breaking change which adds functionality)_


