### PR TITLE
Mark DITA-OT Users Google Group as archived

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -57,7 +57,7 @@
           <li><a href="{{ site.baseurl }}/support">Support Forums</a></li>
           <li><a href="https://groups.io/g/dita-users">DITA Users Group</a></li>
           <li><a href="https://github.com/orgs/dita-ot/discussions">DITA-OT Discussions</a></li>
-          <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users Group</a></li>
+          <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users Group (archive)</a></li>
           <li>
             <a href="http://stackoverflow.com/questions/tagged/dita-ot">Stack Overflow [dita-ot]</a>
           </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -55,9 +55,9 @@
           <li><a href="{{ site.baseurl }}/management">Project Management</a></li>
           <li class="dropdown-divider"></li>
           <li><a href="{{ site.baseurl }}/support">Support Forums</a></li>
-          <li><a href="https://groups.io/g/dita-users">DITA Users Group</a></li>
+          <li><a href="https://groups.io/g/dita-users">DITA Users group</a></li>
           <li><a href="https://github.com/orgs/dita-ot/discussions">DITA-OT Discussions</a></li>
-          <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users Group (archive)</a></li>
+          <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users group archive</a></li>
           <li>
             <a href="http://stackoverflow.com/questions/tagged/dita-ot">Stack Overflow [dita-ot]</a>
           </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -86,7 +86,7 @@
                 >DITA-OT Discussions</a
               >
               <a class="dropdown-item" href="https://groups.google.com/d/forum/dita-ot-users"
-                >DITA-OT Users group</a
+                >DITA-OT Users group (archive)</a
               >
               <a class="dropdown-item" href="http://stackoverflow.com/questions/tagged/dita-ot"
                 >Stack Overflow [dita-ot]</a

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -81,12 +81,12 @@
               <div class="dropdown-divider"></div>
               <h6 class="dropdown-header">Support Forums</h6>
               <a class="dropdown-item" href="{{ site.baseurl }}/support">Community Support</a>
-              <a class="dropdown-item" href="https://groups.io/g/dita-users">DITA Users Group</a>
+              <a class="dropdown-item" href="https://groups.io/g/dita-users">DITA Users group</a>
               <a class="dropdown-item" href="https://github.com/orgs/dita-ot/discussions"
                 >DITA-OT Discussions</a
               >
               <a class="dropdown-item" href="https://groups.google.com/d/forum/dita-ot-users"
-                >DITA-OT Users group (archive)</a
+                >DITA-OT Users group archive</a
               >
               <a class="dropdown-item" href="http://stackoverflow.com/questions/tagged/dita-ot"
                 >Stack Overflow [dita-ot]</a

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -15,9 +15,9 @@
       <li {% if page.url == "/management.html" %} class="active" {% endif %}>
         <a href="{{ site.baseurl }}/management">Project Management</a></li>
     <li class="nav-header">Support Forums</li>
-      <li><a href="https://groups.io/g/dita-users">DITA Users Group</a></li>
+      <li><a href="https://groups.io/g/dita-users">DITA Users group</a></li>
       <li><a href="https://github.com/orgs/dita-ot/discussions">DITA-OT Discussions</a></li>
-      <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users Group (archive)</a></li>
+      <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users group archive</a></li>
       <li><a href="http://stackoverflow.com/questions/tagged/dita-ot">Stack Overflow [dita-ot]</a></li>
       <li><a href="https://www.oasis-open.org/committees/dita/">OASIS DITA TC</a></li>
     <li class="nav-header">About This Website</li>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -17,7 +17,7 @@
     <li class="nav-header">Support Forums</li>
       <li><a href="https://groups.io/g/dita-users">DITA Users Group</a></li>
       <li><a href="https://github.com/orgs/dita-ot/discussions">DITA-OT Discussions</a></li>
-      <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users Group</a></li>
+      <li><a href="https://groups.google.com/d/forum/dita-ot-users">DITA-OT Users Group (archive)</a></li>
       <li><a href="http://stackoverflow.com/questions/tagged/dita-ot">Stack Overflow [dita-ot]</a></li>
       <li><a href="https://www.oasis-open.org/committees/dita/">OASIS DITA TC</a></li>
     <li class="nav-header">About This Website</li>

--- a/contributing.md
+++ b/contributing.md
@@ -13,11 +13,11 @@ Before you do that, [review the open issues][1] to make sure it hasn't already b
 
 ## Community support
 
-You can help give back to the community by answering DITA-OT–related questions on the [DITA-OT Discussions][5], the [DITA Users group][6] or [Stack Overflow][7].
+You can help give back to the community by answering DITA-OT–related questions on the [DITA-OT Discussions][5] forum on GitHub, the [DITA Users][6] group, or [Stack Overflow][7].
 
 ## Development discussions
 
-We use [Slack][8] to discuss DITA-OT development and design issues, plan events and keep tabs on revisions in our GitHub repositories. Developers and vendors using the toolkit are encouraged to join the [DITA-OT Slack team][9] to discuss upcoming changes.
+We use [Slack][8] to discuss DITA-OT development and design issues, plan events and keep tabs on revisions in our GitHub repositories. Developers and vendors using the toolkit are encouraged to join the [DITA-OT Slack][9] workspace to discuss upcoming changes.
 
 To request an invitation and join the conversation, visit [slack.dita-ot.org][10].
 
@@ -25,8 +25,7 @@ To request an invitation and join the conversation, visit [slack.dita-ot.org][10
 
 _Have XSLT or Java coding skills?_
 
-You can contribute fixes to [bugs][11] or new features by sending [pull requests][12] via GitHub, the process of which is described in
-this [Contributing to the Toolkit video][15].
+You can contribute fixes to [bugs][11] or new features by sending [pull requests][12] via GitHub, the process of which is described in this [Contributing to the Toolkit video][15].
 
 ## Documentation
 

--- a/contributing.md
+++ b/contributing.md
@@ -13,7 +13,7 @@ Before you do that, [review the open issues][1] to make sure it hasn't already b
 
 ## Community support
 
-You can help give back to the community by answering DITA-OT–related questions on the [DITA-OT Users group][5], the [DITA Users group][6] or [Stack Overflow][7].
+You can help give back to the community by answering DITA-OT–related questions on the [DITA-OT Discussions][5], the [DITA Users group][6] or [Stack Overflow][7].
 
 ## Development discussions
 
@@ -42,7 +42,7 @@ If you'd like to fix a typo or propose changes to an existing topic, you can use
 [2]: https://github.com/dita-ot/dita-ot/issues/new/choose
 [3]: https://github.com/dita-ot/docs/issues
 [4]: https://github.com/dita-ot/website/issues
-[5]: https://groups.google.com/d/forum/dita-ot-users
+[5]: https://github.com/orgs/dita-ot/discussions
 [6]: https://groups.io/g/dita-users
 [7]: http://stackoverflow.com/questions/tagged/dita-ot
 [8]: https://slack.com

--- a/support.md
+++ b/support.md
@@ -10,7 +10,7 @@ With these limited resources, we can't offer direct support, but the DITA commun
 
 - The [DITA Users group][2] was founded in 2004 as a Yahoo! Group and moved to Groups.io in November 2019. The mailing list addresses the needs of DITA users at all levels of experience, from beginners to experts, and serves as a vital resource for the DITA community.
 - The [DITA-OT Discussions][3] forum on GitHub is a collaborative communication platform that allows members of the community to ask questions, share suggestions, upvote discussions to signal support, and mark questions as anwered.
-- The [DITA-OT Users group][4] is a general interest DITA-OT mailing list for questions on any aspect of the toolkit — from installation and getting started to specific overrides, plug-ins, and customizations.
+- The [DITA-OT Users group (archive)][4] is a general interest DITA-OT mailing list for questions on any aspect of the toolkit — from installation and getting started to specific overrides, plug-ins, and customizations.
 - The Stack Overflow developer community includes [topics related to DITA-OT][5].
 - The [OASIS DITA Technical Committee][6] maintains the DITA standard.
 

--- a/support.md
+++ b/support.md
@@ -8,9 +8,10 @@ DITA Open Toolkit is developed and maintained by a [small group of volunteers][1
 
 With these limited resources, we can't offer direct support, but the DITA community offers several other forums, including:
 
-- The [DITA Users group][2] was founded in 2004 as a Yahoo! Group and moved to Groups.io in November 2019. The mailing list addresses the needs of DITA users at all levels of experience, from beginners to experts, and serves as a vital resource for the DITA community.
-- The [DITA-OT Discussions][3] forum on GitHub is a collaborative communication platform that allows members of the community to ask questions, share suggestions, upvote discussions to signal support, and mark questions as anwered.
-- The [DITA-OT Users group (archive)][4] is a general interest DITA-OT mailing list for questions on any aspect of the toolkit — from installation and getting started to specific overrides, plug-ins, and customizations.
+- The [DITA Users][2] group was founded in 2004 as a Yahoo! Group and moved to Groups.io in November 2019. The mailing list addresses the needs of DITA users at all levels of experience, from beginners to experts, and serves as a vital resource for the DITA community.
+- The [DITA-OT Discussions][3] forum on GitHub is a collaborative communication platform that allows members of the community to ask questions, share suggestions, upvote discussions to signal support, and mark questions as answered.
+- From 2013 to 2024, the [DITA-OT Users][4] group served as a general interest DITA-OT mailing list for questions ranging from installation and getting started to specific overrides, plug-ins, and customizations.  
+  _(Archived in favor of the [DITA-OT Discussions][3] forum.)_
 - The Stack Overflow developer community includes [topics related to DITA-OT][5].
 - The [OASIS DITA Technical Committee][6] maintains the DITA standard.
 


### PR DESCRIPTION
## Description
Mark DITA-OT Users Google Group as archived.

## Motivation and Context
DITA-OT Users Google Group has been archived and is read-only. New discussion is directed to GitHub Discussions.


## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- New feature _(non-breaking change which adds functionality)_


